### PR TITLE
New jppc:open-session function to replace jcs:open

### DIFF
--- a/jsnap/jppc-snap.slax
+++ b/jsnap/jppc-snap.slax
@@ -123,7 +123,7 @@ match / {
 template do_snapshot( $ini-file, $target, $passwd, $section-cmd-ns )
 {
    expr jcs:output("Connecting to ", $USER, "@", $target, " ... ");
-	var $jnx = jcs:open( $target, $USER, $passwd );
+	var $jnx = jppc:open-session( $target, $USER, $passwd );
 	if(not( $jnx )) {
 	   expr jcs:output("Unable to connect to device: ", $target, " ... SKIPPING! ");
 	}

--- a/jsnap/jppc-utils.slax
+++ b/jsnap/jppc-utils.slax
@@ -222,3 +222,37 @@ var $__jppc_rxp_q = $__jppc_q_def _ "(.+)" _ $__jppc_q_def _ $__jppc_v_def;
       <func:result select="false()">;
    }
 }
+
+/* ------------------------------------------------- */
+/* this function is used try netconf as a protocol   */ 
+/* if the session didn't work the first time         */
+/* ------------------------------------------------- */
+<func:function name="jppc:open-session">
+{
+    param $target;
+    param $login;
+    param $pwd;
+   
+    var $session-opt-default := {
+                <username> $login;
+                <password> $pwd;
+                <port> "22";
+        }
+    
+    var $session-opt-netconf := {
+                <method> "netconf";
+                <username> $login;
+                <password> $pwd;
+                <port> "22";
+        }
+    
+	var $jnx-default = jcs:open( $target, $session-opt-default );
+    
+    if(not( $jnx-default )) {
+	   var $jnx-netconf = jcs:open( $target, $session-opt-netconf );
+       <func:result select="$jnx-netconf">;
+	}
+    else {
+        <func:result select="$jnx-default">;
+    }
+}


### PR DESCRIPTION
jppc:open-session will try to open a session using Netconf if the
default configuration doesn't work
