### PR TITLE
Traffic Function

### DIFF
--- a/jsnap/jppc-tests.slax
+++ b/jsnap/jppc-tests.slax
@@ -82,7 +82,6 @@ var $JPPC-TEST-OPERATORS := {
 	<contains>;			            /* <xpath>,"<str-value>" */
 	<contains-rex>;			            /* <xpath>,"<regex-value>" */
 	<traffic diff="">;				   /* <xpath>, [+|-]<value>[%] */
-
 }
 
 var $JPPC-TEST-NAMES = dyn:map($JPPC-TEST-OPERATORS/child::*,'name(.)');


### PR DESCRIPTION
The Delta function does not work as expected, output is not correct when comparing circuit utilization in pre/post checks.  This function was created to find when there is a large variance in traffic volume.  

Example jsnap configuration:  
# List all interfaces that have a 90%+ reduction in traffic unless less than 6kbps in the pre-mop check

traffic {
        command show interfaces detail;
        iterate physical-interface {
            id logical-interface/name;
            traffic logical-interface/transit-traffic-statistics/input-bps, -90%, 6000 {
                info INPUT TRAFFIC -- interfaces with a 90%ç vs pre-check;
                err "############### FAILED INTERFACE UTILIZATION LOW - VERIFICATION NEEDED ###############";
                err "interface %s   %s", $ID.1, $PRE/logical-interface/description;
                err " pre-check: %s bps", $PRE/logical-interface/transit-traffic-statistics/input-bps;
                err " post-check: %s bps", $POST/logical-interface/transit-traffic-statistics/input-bps;

```
        }
        traffic logical-interface/transit-traffic-statistics/output-bps, -90%, 6000 {
            info OUTPUT TRAFFIC -- interfaces with a 90% drop in traffic vs pre-check;
            err "############### FAILED INTERFACE UTILIZATION LOW - VERIFICATION NEEDED ###############";
            err "interface %s   %s", $ID.1, $PRE/logical-interface/description;
            err " pre-check: %s bps", $PRE/logical-interface/transit-traffic-statistics/output-bps;
            err " post-check: %s bps", $POST/logical-interface/transit-traffic-statistics/output-bps;

        }
    }
```

}
